### PR TITLE
Add fog of war overlay and fix location storage

### DIFF
--- a/FogMap/FogMapApp.swift
+++ b/FogMap/FogMapApp.swift
@@ -10,21 +10,19 @@ import CoreData
 
 @main
 struct FogMapApp: App {
-//    let dataController: DataController
-//    let locationManager: LocationManager
-    
+    let dataController: DataController
+    let locationManager: LocationManager
+
     init() {
-//        self.dataController = DataController()
-//        self.dataController = DataController.preview
-//        self.locationManager = LocationManager(viewContext: dataController.container.viewContext)
+        self.dataController = DataController()
+        self.locationManager = LocationManager(viewContext: dataController.container.viewContext)
     }
 
     var body: some Scene {
         WindowGroup {
             MainView()
-//            MapView()
-//                .environment(\.managedObjectContext, dataController.container.viewContext)
-//                .environmentObject(self.locationManager)
+                .environment(\.managedObjectContext, dataController.container.viewContext)
+                .environmentObject(locationManager)
         }
     }
 }

--- a/FogMap/Info.plist
+++ b/FogMap/Info.plist
@@ -6,11 +6,17 @@
 	<false/>
 	<key>ITSEncryptionExportComplianceCode</key>
 	<string>NO</string>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>fetch</string>
-		<string>location</string>
-		<string>remote-notification</string>
-	</array>
+        <key>UIBackgroundModes</key>
+        <array>
+                <string>fetch</string>
+                <string>location</string>
+                <string>remote-notification</string>
+        </array>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>This app needs your location to reveal the map.</string>
+        <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+        <string>This app needs your location to reveal the map even in the background.</string>
+        <key>NSLocationAlwaysUsageDescription</key>
+        <string>This app needs your location to reveal the map even in the background.</string>
 </dict>
 </plist>

--- a/FogMap/LocationManager.swift
+++ b/FogMap/LocationManager.swift
@@ -35,9 +35,10 @@ class LocationManager: NSObject, ObservableObject {
         do {
             let request = NSFetchRequest<PastLocations>(entityName: "PastLocations")
             let res = try viewContext.fetch(request)
-            for location in res {
-                let point = LocationPoint(latitude: location.latitude, longitude: location.longitude, timestamp: Int(location.timestamp))
-                self.locations.append(point)
+            self.locations = res.map {
+                LocationPoint(latitude: $0.latitude,
+                              longitude: $0.longitude,
+                              timestamp: Int($0.timestamp))
             }
         } catch {
             print("Something went wrong fetching locations")
@@ -72,8 +73,8 @@ extension LocationManager: CLLocationManagerDelegate {
         }
     }
     
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard let location = locations.last else { return }
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations newLocations: [CLLocation]) {
+        guard let location = newLocations.last else { return }
         self.userLocation = location
         let date = Int64(Date().timeIntervalSince1970)
         let point = LocationPoint(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude, timestamp: Int(date))
@@ -94,7 +95,6 @@ extension LocationManager: CLLocationManagerDelegate {
             print(error)
             print("SOMETHING WENT WRONG")
         }
-        requestFromCoreData()
     }
     
     func locationManager(_ manager: CLLocationManager, didFailWithError error: any Error) {

--- a/FogMap/StatsView.swift
+++ b/FogMap/StatsView.swift
@@ -13,8 +13,14 @@
 import SwiftUI
 
 struct StatsView: View {
+    @ObservedObject private var locationManager = LocationManager.shared
+
     var body: some View {
-        Text("This is stats")
+        VStack(spacing: 16) {
+            Text("Visited locations: \(locationManager.locations.count)")
+                .font(.title3)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 

--- a/FogMap/UIKitMapView.swift
+++ b/FogMap/UIKitMapView.swift
@@ -99,7 +99,7 @@ class UIKitMapView: UIViewController, MKMapViewDelegate {
         maskView?.removeFromSuperview()
         
         let newMaskView = UIView(frame: mapView.bounds)
-        newMaskView.backgroundColor = UIColor.white
+        newMaskView.backgroundColor = UIColor.black.withAlphaComponent(0.8)
         newMaskView.isUserInteractionEnabled = false
         
         mapView.addSubview(newMaskView)


### PR DESCRIPTION
## Summary
- initialize main app with DataController and LocationManager
- avoid duplicating stored locations and update location manager delegate
- make mask view darker for a fog-of-war look
- expose visited location count in `StatsView`
- add required location usage descriptions to Info.plist

## Testing
- `xcodebuild -list` *(fails: command not found)*