### PR TITLE
Enable background location recording

### DIFF
--- a/FogMap/AppDelegate.swift
+++ b/FogMap/AppDelegate.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        // Instantiate the shared LocationManager so that location monitoring
+        // continues even when the app is launched in the background due to
+        // location updates.
+        _ = LocationManager.shared
+        return true
+    }
+}

--- a/FogMap/FogMapApp.swift
+++ b/FogMap/FogMapApp.swift
@@ -7,9 +7,14 @@
 
 import SwiftUI
 import CoreData
+import UIKit
 
 @main
 struct FogMapApp: App {
+    // Bridge UIKit's AppDelegate to ensure location monitoring is started even
+    // when the application is relaunched in the background.
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
 //    let dataController: DataController
 //    let locationManager: LocationManager
     

--- a/FogMap/Info.plist
+++ b/FogMap/Info.plist
@@ -7,10 +7,16 @@
 	<key>ITSEncryptionExportComplianceCode</key>
 	<string>NO</string>
 	<key>UIBackgroundModes</key>
-	<array>
-		<string>fetch</string>
-		<string>location</string>
-		<string>remote-notification</string>
-	</array>
+  <array>
+          <string>fetch</string>
+          <string>location</string>
+          <string>remote-notification</string>
+  </array>
+  <key>NSLocationWhenInUseUsageDescription</key>
+  <string>We use your location to visualize visited areas.</string>
+  <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+  <string>We track your location even in the background to update visited areas.</string>
+  <key>NSLocationAlwaysUsageDescription</key>
+  <string>We track your location even in the background to update visited areas.</string>
 </dict>
 </plist>

--- a/FogMap/LocationManager.swift
+++ b/FogMap/LocationManager.swift
@@ -28,7 +28,12 @@ class LocationManager: NSObject, ObservableObject {
         manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
         manager.distanceFilter = 100
         manager.allowsBackgroundLocationUpdates = true
+        manager.pausesLocationUpdatesAutomatically = false
         manager.startUpdatingLocation()
+        // Monitor significant changes so updates continue even when the app
+        // is terminated. The system relaunches the app in the background when
+        // a significant change occurs.
+        manager.startMonitoringSignificantLocationChanges()
     }
     
     func requestFromCoreData() {


### PR DESCRIPTION
## Summary
- add an `AppDelegate` to ensure `LocationManager` is created when the app starts in the background
- start monitoring significant location changes so updates continue after the app is terminated
- expose `AppDelegate` to SwiftUI entry point
- update Info.plist with location usage messages

## Testing
- `swift --version`