### PR TITLE
Enable background location recording

### DIFF
--- a/FogMap.xcodeproj/project.pbxproj
+++ b/FogMap.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		6CA16DF12C5E57A2000C390B /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA16DF02C5E57A2000C390B /* LocationManager.swift */; };
 		6CA16DF42C5ECE96000C390B /* LocationPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA16DF32C5ECE96000C390B /* LocationPoint.swift */; };
 		6CE095672C620E2E00D3F745 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6CE095662C620E2E00D3F745 /* LaunchScreen.storyboard */; };
+                16302F6EA7767B05D99F19E3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827648ADCF5F3E86C5711116 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +43,7 @@
 		6CA16DF22C5E6D94000C390B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		6CA16DF32C5ECE96000C390B /* LocationPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationPoint.swift; sourceTree = "<group>"; };
 		6CE095662C620E2E00D3F745 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+                827648ADCF5F3E86C5711116 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +82,7 @@
 				6CA16DF22C5E6D94000C390B /* Info.plist */,
 				6CA16DE92C5E3181000C390B /* Model */,
 				6CA16DD22C5E3076000C390B /* FogMapApp.swift */,
+                                827648ADCF5F3E86C5711116 /* AppDelegate.swift */,
 				6CA16DEA2C5E320E000C390B /* DataController.swift */,
 				6C79781A2C5FB658008C4161 /* UIKitMapView.swift */,
 				6C938FB82C60FF2200F9C139 /* MainView.swift */,
@@ -191,6 +194,7 @@
 				6C79781B2C5FB658008C4161 /* UIKitMapView.swift in Sources */,
 				6C3B4C132C638B9D000DDE78 /* StatsView.swift in Sources */,
 				6CA16DD32C5E3076000C390B /* FogMapApp.swift in Sources */,
+                                16302F6EA7767B05D99F19E3 /* AppDelegate.swift in Sources */,
 				6C3B4C112C6389AA000DDE78 /* SettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FogMap/AppDelegate.swift
+++ b/FogMap/AppDelegate.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        // Instantiate the shared LocationManager so that location monitoring
+        // continues even when the app is launched in the background due to
+        // location updates.
+        _ = LocationManager.shared
+        return true
+    }
+}

--- a/FogMap/FogMapApp.swift
+++ b/FogMap/FogMapApp.swift
@@ -7,9 +7,14 @@
 
 import SwiftUI
 import CoreData
+import UIKit
 
 @main
 struct FogMapApp: App {
+    // Bridge UIKit's AppDelegate to ensure location monitoring is started even
+    // when the application is relaunched in the background.
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
 //    let dataController: DataController
 //    let locationManager: LocationManager
     

--- a/FogMap/Info.plist
+++ b/FogMap/Info.plist
@@ -7,10 +7,16 @@
 	<key>ITSEncryptionExportComplianceCode</key>
 	<string>NO</string>
 	<key>UIBackgroundModes</key>
-	<array>
-		<string>fetch</string>
-		<string>location</string>
-		<string>remote-notification</string>
-	</array>
+  <array>
+          <string>fetch</string>
+          <string>location</string>
+          <string>remote-notification</string>
+  </array>
+  <key>NSLocationWhenInUseUsageDescription</key>
+  <string>We use your location to visualize visited areas.</string>
+  <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+  <string>We track your location even in the background to update visited areas.</string>
+  <key>NSLocationAlwaysUsageDescription</key>
+  <string>We track your location even in the background to update visited areas.</string>
 </dict>
 </plist>

--- a/FogMap/LocationManager.swift
+++ b/FogMap/LocationManager.swift
@@ -28,7 +28,12 @@ class LocationManager: NSObject, ObservableObject {
         manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
         manager.distanceFilter = 100
         manager.allowsBackgroundLocationUpdates = true
+        manager.pausesLocationUpdatesAutomatically = false
         manager.startUpdatingLocation()
+        // Monitor significant changes so updates continue even when the app
+        // is terminated. The system relaunches the app in the background when
+        // a significant change occurs.
+        manager.startMonitoringSignificantLocationChanges()
     }
     
     func requestFromCoreData() {


### PR DESCRIPTION
## Summary
- add an `AppDelegate` to ensure `LocationManager` is created when the app starts in the background
- start monitoring significant location changes so updates continue after the app is terminated
- expose `AppDelegate` to SwiftUI entry point
- update Info.plist with location usage messages
- add `AppDelegate.swift` to the Xcode project file so it builds

## Testing
- `swift --version`
