### PR TITLE
Add screen time tab

### DIFF
--- a/FogMap/FogMap.entitlements
+++ b/FogMap/FogMap.entitlements
@@ -8,9 +8,11 @@
 	<array>
 		<string>iCloud.com.oliverhnat.FogMap</string>
 	</array>
-	<key>com.apple.developer.icloud-services</key>
-	<array>
-		<string>CloudKit</string>
-	</array>
+        <key>com.apple.developer.icloud-services</key>
+        <array>
+                <string>CloudKit</string>
+        </array>
+        <key>com.apple.developer.family-controls</key>
+        <true/>
 </dict>
 </plist>

--- a/FogMap/MainView.swift
+++ b/FogMap/MainView.swift
@@ -32,6 +32,12 @@ struct MainView: View {
                             Text("Statistics")
                             Image(systemName: "chart.bar")
                         }
+                    ScreenTimeView()
+                        .tag("ScreenTime")
+                        .tabItem {
+                            Image(systemName: "clock")
+                            Text("Screen Time")
+                        }
                     SettingsView()
                         .tag("Settings")
                         .tabItem {

--- a/FogMap/ScreenTimeManager.swift
+++ b/FogMap/ScreenTimeManager.swift
@@ -1,0 +1,55 @@
+//
+//  ScreenTimeManager.swift
+//  FogMap
+//
+
+import Foundation
+import FamilyControls
+import DeviceActivity
+
+@MainActor
+class ScreenTimeManager: ObservableObject {
+    @Published var totalScreenTime: TimeInterval = 0
+    @Published var authorizationStatus: AuthorizationStatus = AuthorizationCenter.shared.authorizationStatus
+
+    func requestAuthorization() {
+        Task {
+            do {
+                try await AuthorizationCenter.shared.requestAuthorization(for: .individual)
+                authorizationStatus = AuthorizationCenter.shared.authorizationStatus
+                await fetchScreenTime()
+            } catch {
+                authorizationStatus = AuthorizationCenter.shared.authorizationStatus
+                print("Failed to request authorization: \(error)")
+            }
+        }
+    }
+
+    func fetchScreenTime() async {
+        guard authorizationStatus == .authorized else { return }
+
+        let store = DeviceActivityReportStore()
+        let now = Date()
+        let startOfDay = Calendar.current.startOfDay(for: now)
+        let interval = DateInterval(start: startOfDay, end: now)
+        let query = DeviceActivityReportQuery(during: interval, filter: .total)
+
+        do {
+            for try await result in store.execute(query) {
+                if case .totalActivity(let report) = result {
+                    totalScreenTime = report.activityDuration
+                }
+            }
+        } catch {
+            print("Failed to fetch screen time: \(error)")
+        }
+    }
+
+    func formattedScreenTime() -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.unitsStyle = .full
+        return formatter.string(from: totalScreenTime) ?? "0m"
+    }
+}
+

--- a/FogMap/ScreenTimeView.swift
+++ b/FogMap/ScreenTimeView.swift
@@ -1,0 +1,38 @@
+//
+//  ScreenTimeView.swift
+//  FogMap
+//
+
+import SwiftUI
+
+struct ScreenTimeView: View {
+    @StateObject private var manager = ScreenTimeManager()
+
+    var body: some View {
+        VStack(spacing: 20) {
+            if manager.authorizationStatus == .authorized {
+                Text("Today's Screen Time")
+                    .font(.title2)
+                Text(manager.formattedScreenTime())
+                    .font(.largeTitle)
+            } else {
+                Text("Screen Time access is required.")
+                    .multilineTextAlignment(.center)
+                Button("Grant Permission") {
+                    manager.requestAuthorization()
+                }
+            }
+        }
+        .padding()
+        .task {
+            if manager.authorizationStatus == .authorized {
+                await manager.fetchScreenTime()
+            }
+        }
+    }
+}
+
+#Preview {
+    ScreenTimeView()
+}
+


### PR DESCRIPTION
## Summary
- add screen time view to bottom navigation
- implement ScreenTimeManager to request authorization and fetch usage
- enable Family Controls entitlement

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_b_688e5f664d308322b4a09d42fcbcd04f